### PR TITLE
Start official race with hotkey

### DIFF
--- a/src/system rest.lua
+++ b/src/system rest.lua
@@ -6,3 +6,6 @@ MSG:consumeQueue()
 
 --INPUT TEXT (*)
 handleTextCommandInput(text)
+
+--ACTION START 'option1'
+handleTextCommandInput("startRace")


### PR DESCRIPTION
This minor change would allow to start an official race with a hotkey, so people don't have to mess with the text command.
Text command will still be available though.